### PR TITLE
Fix gzip_types syntax in nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,7 +26,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
-    gzip_types: application/json;
+    gzip_types application/json;
 
     server {
         listen 80;


### PR DESCRIPTION
## Summary
- fix typo in `gzip_types` directive

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f7693c728832dacf8de4fb3599b83